### PR TITLE
build(deps)!: update dependencies across 15 packages

### DIFF
--- a/solution/gradle/libs.versions.toml
+++ b/solution/gradle/libs.versions.toml
@@ -19,22 +19,22 @@
 # Build-related plugins
 android-application = "8.13.0"
 kotlin-android = "2.2.10"
-hilt-android = "2.57.1"
+hilt-android = "2.60.1"
 secrets-gradle-plugin = "2.0.1"
 
 # AndroidX
-core-ktx = "1.17.0"
-lifecycle-runtime-ktx = "2.9.3"
-activity-compose = "1.10.1"
+core-ktx = "1.19.0"
+lifecycle-runtime-ktx = "2.11.0"
+activity-compose = "1.13.0"
 
 # Compose
-compose-bom = "2025.08.01"
+compose-bom = "2026.06.01"
 
 # Testing
 junit = "4.13.2"
-robolectric = "4.16"
+robolectric = "4.16.1"
 test-core = "1.7.0"
-truth = "1.4.4"
+truth = "1.4.5"
 test-ext-junit = "1.3.0"
 espresso-core = "3.7.0"
 

--- a/starter/gradle/libs.versions.toml
+++ b/starter/gradle/libs.versions.toml
@@ -19,28 +19,28 @@
 # Build-related plugins
 android-application = "8.13.0"
 kotlin-android = "2.2.10"
-hilt-android = "2.57.1"
+hilt-android = "2.60.1"
 secrets-gradle-plugin = "2.0.1"
 
 # AndroidX
-core-ktx = "1.17.0"
-lifecycle-runtime-ktx = "2.9.3"
-activity-compose = "1.10.1"
+core-ktx = "1.19.0"
+lifecycle-runtime-ktx = "2.11.0"
+activity-compose = "1.13.0"
 
 # Compose
-compose-bom = "2025.08.01"
+compose-bom = "2026.06.01"
 
 # Testing
 junit = "4.13.2"
-robolectric = "4.16"
+robolectric = "4.16.1"
 test-core = "1.7.0"
-truth = "1.4.4"
+truth = "1.4.5"
 test-ext-junit = "1.3.0"
 espresso-core = "3.7.0"
 
 # Google Maps
 maps-compose = "6.10.0"
-play-services-maps = "19.2.0"
+play-services-maps = "20.0.0"
 maps-ktx = "5.2.0"
 maps-utils-ktx = "5.2.0"
 


### PR DESCRIPTION
build(deps)!: update dependencies across 15 packages

Automated dependency updates applied:
- androidx.core:core-ktx 1.17.0 -> 1.19.0 (solution)
- androidx.lifecycle:lifecycle-runtime-ktx 2.9.3 -> 2.11.0 (solution)
- androidx.activity:activity-compose 1.10.1 -> 1.13.0 (solution)
- 🛑 androidx.compose:compose-bom 2025.08.01 -> 2026.06.01 (solution)
- com.google.dagger:hilt-android 2.57.1 -> 2.60.1 (solution)
- org.robolectric:robolectric 4.16 -> 4.16.1 (solution)
- com.google.truth:truth 1.4.4 -> 1.4.5 (solution)
- androidx.core:core-ktx 1.17.0 -> 1.19.0 (starter)
- androidx.lifecycle:lifecycle-runtime-ktx 2.9.3 -> 2.11.0 (starter)
- androidx.activity:activity-compose 1.10.1 -> 1.13.0 (starter)
- 🛑 androidx.compose:compose-bom 2025.08.01 -> 2026.06.01 (starter)
- com.google.dagger:hilt-android 2.57.1 -> 2.60.1 (starter)
- org.robolectric:robolectric 4.16 -> 4.16.1 (starter)
- com.google.truth:truth 1.4.4 -> 1.4.5 (starter)
- 🛑 com.google.android.gms:play-services-maps 19.2.0 -> 20.0.0 (starter)