### PR TITLE
chore: update maps dependencies and compileSdk to 37

### DIFF
--- a/solution/app/build.gradle.kts
+++ b/solution/app/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 
 android {
     namespace = "com.example.mountainmarkers"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         applicationId = "com.example.mountainmarkers"
@@ -37,13 +37,16 @@ android {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
     }
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
     buildFeatures {
         compose = true
         buildConfig = true
     }
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8)
+    }
+}
     
     packaging {
         resources {
@@ -72,6 +75,7 @@ dependencies {
     implementation(libs.androidx.compose.ui.graphics)
     implementation(libs.androidx.compose.ui.tooling.preview)
     implementation(libs.androidx.compose.material3)
+    implementation("androidx.compose.material:material-icons-extended")
 
     testImplementation(libs.junit)
     testImplementation(libs.robolectric)
@@ -89,6 +93,7 @@ dependencies {
     // Hilt
     implementation(libs.hilt.android)
     kapt(libs.hilt.android.compiler)
+    kapt("org.jetbrains.kotlin:kotlin-metadata-jvm:2.3.0")
     implementation(libs.kotlin.reflect)
 
     // Google Maps Compose library

--- a/solution/app/src/main/java/com/example/mountainmarkers/presentation/ClusteringMarkersMapContent.kt
+++ b/solution/app/src/main/java/com/example/mountainmarkers/presentation/ClusteringMarkersMapContent.kt
@@ -35,6 +35,7 @@ import com.example.mountainmarkers.data.local.Mountain
 import com.example.mountainmarkers.data.local.is14er
 import com.example.mountainmarkers.data.utils.LocalUnitsConverter
 import com.example.mountainmarkers.presentation.MountainsScreenViewState.MountainList
+import com.google.android.gms.maps.model.LatLng
 import com.google.maps.android.clustering.Cluster
 import com.google.maps.android.clustering.ClusterItem
 import com.google.maps.android.compose.GoogleMapComposable
@@ -47,10 +48,10 @@ data class MountainClusterItem(
     val mountain: Mountain,
     val snippetString: String
 ) : ClusterItem {
-    override fun getPosition() = mountain.location
-    override fun getTitle() = mountain.name
-    override fun getSnippet() = snippetString
-    override fun getZIndex() = 0f
+    override val position: LatLng get() = mountain.location
+    override val title: String get() = mountain.name
+    override val snippet: String get() = snippetString
+    override val zIndex: Float get() = 0f
 }
 
 /**

--- a/solution/gradle.properties
+++ b/solution/gradle.properties
@@ -21,3 +21,4 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+android.suppressUnsupportedCompileSdk=37,37.0

--- a/solution/gradle/libs.versions.toml
+++ b/solution/gradle/libs.versions.toml
@@ -39,7 +39,7 @@ test-ext-junit = "1.3.0"
 espresso-core = "3.7.0"
 
 # Google Maps
-maps-compose = "8.3.1-rc03"
+maps-compose = "8.3.1"
 
 [libraries]
 # AndroidX. These libraries provide core Android functionality, lifecycle management, and Compose integration.

--- a/solution/gradle/libs.versions.toml
+++ b/solution/gradle/libs.versions.toml
@@ -18,7 +18,7 @@
 [versions]
 # Build-related plugins
 android-application = "8.13.0"
-kotlin-android = "2.2.10"
+kotlin-android = "2.3.10"
 hilt-android = "2.57.1"
 secrets-gradle-plugin = "2.0.1"
 
@@ -39,7 +39,7 @@ test-ext-junit = "1.3.0"
 espresso-core = "3.7.0"
 
 # Google Maps
-maps-compose = "6.10.0"
+maps-compose = "8.3.1-rc03"
 
 [libraries]
 # AndroidX. These libraries provide core Android functionality, lifecycle management, and Compose integration.

--- a/solution/settings.gradle.kts
+++ b/solution/settings.gradle.kts
@@ -8,6 +8,7 @@ pluginManagement {
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
+        mavenLocal()
         google()
         mavenCentral()
     }

--- a/solution/settings.gradle.kts
+++ b/solution/settings.gradle.kts
@@ -8,7 +8,10 @@ pluginManagement {
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
-        mavenLocal()
+        if (providers.gradleProperty("useMavenLocal").orNull == "true" ||
+            providers.environmentVariable("USE_MAVEN_LOCAL").orNull == "true") {
+            mavenLocal()
+        }
         google()
         mavenCentral()
     }

--- a/starter/app/build.gradle.kts
+++ b/starter/app/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
 
 android {
     namespace = "com.example.mountainmarkers"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         applicationId = "com.example.mountainmarkers"
@@ -37,13 +37,16 @@ android {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
     }
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
     buildFeatures {
         compose = true
         buildConfig = true
     }
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8)
+    }
+}
     
     packaging {
         resources {
@@ -89,6 +92,7 @@ dependencies {
     // Hilt
     implementation(libs.hilt.android)
     kapt(libs.hilt.android.compiler)
+    kapt("org.jetbrains.kotlin:kotlin-metadata-jvm:2.3.0")
     implementation(libs.kotlin.reflect)
 
     // Google Maps SDK -- these are here for the data model.  Remove these dependencies and replace

--- a/starter/gradle.properties
+++ b/starter/gradle.properties
@@ -21,3 +21,4 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+android.suppressUnsupportedCompileSdk=37,37.0

--- a/starter/gradle/libs.versions.toml
+++ b/starter/gradle/libs.versions.toml
@@ -39,10 +39,10 @@ test-ext-junit = "1.3.0"
 espresso-core = "3.7.0"
 
 # Google Maps
-maps-compose = "8.3.1-rc03"
+maps-compose = "8.3.1"
 play-services-maps = "19.2.0"
-maps-ktx = "6.1.0-rc03"
-maps-utils-ktx = "6.1.0-rc03"
+maps-ktx = "6.1.0"
+maps-utils-ktx = "6.1.0"
 
 [libraries]
 # AndroidX. These libraries provide core Android functionality, lifecycle management, and Compose integration.

--- a/starter/gradle/libs.versions.toml
+++ b/starter/gradle/libs.versions.toml
@@ -18,7 +18,7 @@
 [versions]
 # Build-related plugins
 android-application = "8.13.0"
-kotlin-android = "2.2.10"
+kotlin-android = "2.3.10"
 hilt-android = "2.57.1"
 secrets-gradle-plugin = "2.0.1"
 
@@ -39,10 +39,10 @@ test-ext-junit = "1.3.0"
 espresso-core = "3.7.0"
 
 # Google Maps
-maps-compose = "6.10.0"
+maps-compose = "8.3.1-rc03"
 play-services-maps = "19.2.0"
-maps-ktx = "5.2.0"
-maps-utils-ktx = "5.2.0"
+maps-ktx = "6.1.0-rc03"
+maps-utils-ktx = "6.1.0-rc03"
 
 [libraries]
 # AndroidX. These libraries provide core Android functionality, lifecycle management, and Compose integration.

--- a/starter/settings.gradle.kts
+++ b/starter/settings.gradle.kts
@@ -8,6 +8,7 @@ pluginManagement {
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
+        mavenLocal()
         google()
         mavenCentral()
     }

--- a/starter/settings.gradle.kts
+++ b/starter/settings.gradle.kts
@@ -8,7 +8,10 @@ pluginManagement {
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
     repositories {
-        mavenLocal()
+        if (providers.gradleProperty("useMavenLocal").orNull == "true" ||
+            providers.environmentVariable("USE_MAVEN_LOCAL").orNull == "true") {
+            mavenLocal()
+        }
         google()
         mavenCentral()
     }


### PR DESCRIPTION
Updates codelab dependencies to maps-compose 8.3.1-rc03 and maps-ktx 6.1.0-rc03, and adapts Kotlin ClusterItem properties.